### PR TITLE
Add option to hide completed colors and show remaining pixels

### DIFF
--- a/src/templateManager.js
+++ b/src/templateManager.js
@@ -897,6 +897,22 @@ export default class TemplateManager {
     await this.storeUserSettings();
   }
 
+  /** A utility to check if completed colors are set to be hidden.
+   * @since 0.85.22
+   */
+  areCompletedColorsHidden() {
+    return this.userSettings?.hideCompletedColors ?? false;
+  }
+
+  /** Sets the `hideCompletedColors` boolean in the `userSettings` to a value.
+   * @param {boolean} value - The value to set the boolean to
+   * @since 0.85.22
+   */
+  async setHideCompletedColors(value) {
+    this.userSettings.hideCompletedColors = value;
+    await this.storeUserSettings();
+  }
+
   /** Sets the `extraColorsBitmap` to an updated mask, refresh the color filter if changed.
    * @param {number} value - The value to set the mask to
    * @since 0.85.17


### PR DESCRIPTION
Adds a "Hide Completed Colors" checkbox to allow users to focus on colors that are not yet complete.

When this option is checked:
- The color list hides colors that are 100% placed.
- Each color item displays the number of remaining pixels to be placed.
- The list is sorted by the remaining pixel count in descending order.

When unchecked, the list reverts to the original display format (placed / total).